### PR TITLE
Added an ansible.cfg to disable host_key_checking

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+host_key_checking = False


### PR DESCRIPTION
Adding an ansible.cfg to disable host key checks in Ansible